### PR TITLE
fix(default output path): Changed default output path to home_dir/patreon-dl to ensure permission allowed

### DIFF
--- a/src/main/config/UIConfig.ts
+++ b/src/main/config/UIConfig.ts
@@ -7,6 +7,11 @@ import {
   type DownloaderOptions
 } from "patreon-dl";
 import { getDefaultFileLoggerOptions } from "../util/Config";
+import os from "os";
+import path from "path";
+
+// Override patreon-dl default output path to user's home directory
+const defaultOutputPath = path.join(os.homedir(), 'patreon-dl');
 
 export function getStartupUIConfig(): UIConfig {
   return convertPatreonDLOptionsToUIConfig(getDefaultDownloaderOptions());
@@ -48,7 +53,7 @@ function convertPatreonDLOptionsToUIConfig(
       "dry.run": p.dryRun
     },
     output: {
-      "out.dir": p.outDir,
+      "out.dir": defaultOutputPath,
       "campaign.dir.name.format": p.dirNameFormat.campaign,
       "content.dir.name.format": p.dirNameFormat.content,
       "media.filename.format": p.filenameFormat.media,


### PR DESCRIPTION
This is necessary as patreon-dl defaults to current working directory, which when the GUI app is called, it will default to the installation path in program files. On Windows, program files is a protected directory. Hence, the path is replaced with /userdir/ which is also used by other program such as yt-dlp. 

path.join(os.homedir(), 'patreon-dl') should work on Windows, Linux, and MacOS. 