### PR TITLE
fix: identify target from browser URL when Patreon page data omits it

### DIFF
--- a/src/main/PatreonPageAnalyzer.ts
+++ b/src/main/PatreonPageAnalyzer.ts
@@ -12,6 +12,12 @@ export interface AnalyzerRequestOptions {
   } | null;
   userAgent: string;
   cookie: string;
+  /**
+   * URL of the page currently loaded in the browser view. Used as fallback
+   * for identifying the target when the page data returned by Patreon does
+   * not contain the information needed to do so.
+   */
+  currentURL?: string;
 }
 
 // "Custom domain" paths and rules not fully tested.
@@ -59,6 +65,27 @@ const PAGE_PATHNAME_FORMATS = {
     "/cw/_customdomain/shop"
   ]
 };
+
+// First path segment of URLs that do not refer to a creator's vanity.
+const NON_VANITY_PATH_SEGMENTS = [
+  "posts",
+  "collection",
+  "user",
+  "home",
+  "search",
+  "explore",
+  "checkout",
+  "join",
+  "login",
+  "signup",
+  "settings",
+  "messages",
+  "notifications",
+  "api",
+  "oauth2",
+  "dashboard",
+  "creator-hub"
+];
 
 const NEXTJS_PATHNAME_REGEX = {
   postsByUser: [
@@ -158,10 +185,16 @@ export default class PatreonPageAnalyzer {
       const _an = (an = this.#analyzePage(json));
       tiers = this.#getTiers(json);
       campaignId = _an?.campaignId ?? null;
+      if (!an) {
+        an = this.#analyzeURL(requestOptions.currentURL);
+      }
     } else {
       const isNextJSStreamingResponse = html.includes("self.__next_f.push");
       if (isNextJSStreamingResponse) {
-        an = this.#analyzeNextJSStreamingResponse(html);
+        an = this.#analyzeNextJSStreamingResponse(
+          html,
+          requestOptions.currentURL
+        );
         try {
           const ct = await this.#getCampaignIdAndTiersFromStreamingResponse(
             html,
@@ -259,24 +292,6 @@ export default class PatreonPageAnalyzer {
       campaignId
     );
 
-    const __parseSlugId = (s: string) => {
-      // Check if ID only - no slug
-      if (!isNaN(Number(s))) {
-        return {
-          slug: null,
-          id: s
-        };
-      }
-      const match = /(.+)-(\d+)$/.exec(s);
-      if (match?.length === 3) {
-        return {
-          slug: match[1],
-          id: match[2]
-        };
-      }
-      return { slug: null, id: null };
-    };
-
     if (
       PAGE_PATHNAME_FORMATS.postsByUser.includes(page) &&
       typeof userId === "string"
@@ -315,7 +330,7 @@ export default class PatreonPageAnalyzer {
       PAGE_PATHNAME_FORMATS.post.includes(page) &&
       typeof postId === "string"
     ) {
-      const { slug, id } = __parseSlugId(postId);
+      const { slug, id } = this.#parseSlugId(postId);
       if (id) {
         const an: URLAnalysis = {
           type: "post",
@@ -355,7 +370,7 @@ export default class PatreonPageAnalyzer {
       typeof vanity === "string" &&
       typeof productId === "string"
     ) {
-      const { slug, id } = __parseSlugId(productId);
+      const { slug, id } = this.#parseSlugId(productId);
       if (slug && id) {
         const an: URLAnalysis = {
           type: "product",
@@ -393,7 +408,10 @@ export default class PatreonPageAnalyzer {
     return null;
   }
 
-  static #analyzeNextJSStreamingResponse(html: string): PageAnalysis | null {
+  static #analyzeNextJSStreamingResponse(
+    html: string,
+    currentURL?: string
+  ): PageAnalysis | null {
     const vanityRegex =
       /\\(?:\\?)"vanity\\(?:\\?)":\\(?:\\?)"(.+?)\\(?:\\?)"/gm;
     const vanityMatch = vanityRegex.exec(html);
@@ -411,7 +429,9 @@ export default class PatreonPageAnalyzer {
       pathname
     );
     if (!pathname) {
-      return null;
+      // Patreon no longer includes "pathname" in every streaming response.
+      // Fall back to the URL of the page loaded in the browser view.
+      return this.#analyzeURL(currentURL);
     }
 
     if (
@@ -469,7 +489,133 @@ export default class PatreonPageAnalyzer {
         }
       };
     }
-    return null;
+    return this.#analyzeURL(currentURL);
+  }
+
+  /**
+   * Identifies the target from the URL of the page loaded in the browser view.
+   * This is a fallback for when the page data returned by Patreon does not
+   * contain the information needed to identify the target. It covers the same
+   * URL formats as `PAGE_PATHNAME_FORMATS`.
+   */
+  static #analyzeURL(currentURL?: string): PageAnalysis | null {
+    if (!currentURL) {
+      return null;
+    }
+    let url: URL;
+    try {
+      url = new URL(currentURL);
+    } catch (_error: unknown) {
+      console.warn(`PatreonPageAnalyzer: invalid URL "${currentURL}"`);
+      return null;
+    }
+    console.debug(`PatreonPageAnalyzer: analyzing URL "${currentURL}"`);
+
+    const segments = url.pathname
+      .split("/")
+      .filter((segment) => segment.length > 0)
+      .map((segment) => {
+        try {
+          return decodeURIComponent(segment);
+        } catch (_error: unknown) {
+          return segment;
+        }
+      });
+    // "/cw" and "/c" prefixes do not affect what the rest of the path refers to.
+    if (segments[0] === "cw" || segments[0] === "c") {
+      segments.shift();
+    }
+    const [first, second, third] = segments;
+
+    const __result = (
+      an: URLAnalysis,
+      normalizedURL: string
+    ): PageAnalysis => ({
+      normalizedURL,
+      target: {
+        ...an,
+        description: this.#getTargetDesc(an)
+      }
+    });
+
+    // /user/posts?u=[userId]
+    const userId = url.searchParams.get("u");
+    if (first === "user" && userId) {
+      return __result(
+        { type: "postsByUserId", userId },
+        `${PATREON_URL}/user/posts?u=${userId}`
+      );
+    }
+
+    // /posts/[postId]
+    if (first === "posts" && second) {
+      const { slug, id } = this.#parseSlugId(second);
+      if (id) {
+        return __result(
+          { type: "post", postId: id, slug: slug ?? undefined },
+          `${PATREON_URL}/posts/${second}`
+        );
+      }
+      return null;
+    }
+
+    // /collection/[collectionId]
+    if (first === "collection" && second) {
+      const { id } = this.#parseSlugId(second);
+      const collectionId = id || second;
+      return __result(
+        { type: "postsByCollection", collectionId },
+        `${PATREON_URL}/collection/${collectionId}`
+      );
+    }
+
+    if (!first || NON_VANITY_PATH_SEGMENTS.includes(first)) {
+      return null;
+    }
+
+    // /[vanity]/shop/[productId]
+    if (second === "shop" && third) {
+      const { slug, id } = this.#parseSlugId(third);
+      if (slug && id) {
+        return __result(
+          { type: "product", productId: id, slug },
+          `${PATREON_URL}/${first}/shop/${third}`
+        );
+      }
+      return null;
+    }
+
+    // /[vanity]/shop
+    if (second === "shop") {
+      return __result(
+        { type: "shop", vanity: first },
+        `${PATREON_URL}/${first}/shop`
+      );
+    }
+
+    // /[vanity]/[[...tab]]
+    return __result(
+      { type: "postsByUser", vanity: first },
+      `${PATREON_URL}/${first}/posts`
+    );
+  }
+
+  static #parseSlugId(s: string) {
+    // Check if ID only - no slug
+    if (!isNaN(Number(s))) {
+      return {
+        slug: null,
+        id: s
+      };
+    }
+    const match = /(.+)-(\d+)$/.exec(s);
+    if (match?.length === 3) {
+      return {
+        slug: match[1],
+        id: match[2]
+      };
+    }
+    return { slug: null, id: null };
   }
 
   static async #getCampaignIdAndTiersFromStreamingResponse(

--- a/src/main/PatreonPageAnalyzer.ts
+++ b/src/main/PatreonPageAnalyzer.ts
@@ -573,6 +573,18 @@ export default class PatreonPageAnalyzer {
       return null;
     }
 
+    // /[vanity]/posts/[postId]
+    if (second === "posts" && third) {
+      const { slug, id } = this.#parseSlugId(third);
+      if (id) {
+        return __result(
+          { type: "post", postId: id, slug: slug ?? undefined },
+          `${PATREON_URL}/posts/${third}`
+        );
+      }
+      return null;
+    }
+
     // /[vanity]/shop/[productId]
     if (second === "shop" && third) {
       const { slug, id } = this.#parseSlugId(third);

--- a/src/main/views/browser/WebBrowserView.ts
+++ b/src/main/views/browser/WebBrowserView.ts
@@ -445,7 +445,8 @@ export default class WebBrowserView extends WebContentsView {
               const an = await PatreonPageAnalyzer.analyze(html, signal, {
                 proxy: this.#proxy,
                 userAgent: WebBrowserView.#userAgent,
-                cookie
+                cookie,
+                currentURL: this.webContents.getURL()
               });
               if (an.status === "complete") {
                 resolve(an);


### PR DESCRIPTION
Fixes the open issue **"No Target URL error (likely from Patreon side)"** — no target identified on creator pages or on individual posts.

### Cause

Patreon's Next.js streaming payload no longer contains the `"pathname"` key that `#analyzeNextJSStreamingResponse` relies on. Verified against live HTML for `/cw/{vanity}/posts` captured 2026-09-05: no `__NEXT_DATA__`, `self.__next_f.push` present, zero occurrences of `\"pathname\":\"`, while `\"vanity\"` and `campaign_id\",\"unit_id\"` are still present.

So the analyzer returns early at `if (!pathname) return null`, but `campaignId` is still found — the result is `status: "complete"` with `target: null`, which surfaces as **"No target identified"**. Individual posts fail for a second reason: `NEXTJS_PATHNAME_REGEX` has no `post` entry at all.

### Fix

Adds `AnalyzerRequestOptions.currentURL` (supplied by `WebBrowserView` via `webContents.getURL()`) and a `#analyzeURL()` fallback, used when the page data does not identify the target. It covers the same formats as `PAGE_PATHNAME_FORMATS`: post, postsByUser, postsByUserId, postsByCollection, shop, product, `/cw/` + `/c/` + bare-vanity prefixes, tab pages and custom domains. `__parseSlugId` is lifted to a static method and reused rather than duplicated.

The fallback runs only inside branches where page data was actually found, so `bootstrapNotFound` semantics are unchanged and the browser view keeps polling on pages whose data has not loaded yet.

### Verification

15 URL cases driven through `analyze()` against the live HTML above: 0/12 targets identified before the change, 12/12 after, with non-target pages (`/home`, `/`) still correctly rejected and a guard confirming that a page with no Patreon data does not resolve early. `tsc --noEmit` and `eslint` are clean. Also built and run via `npm run start` against live Patreon — creator pages and individual posts both resolve.

Credit to @tiansun2, who identified the URL-fallback approach in the issue thread; this generalises it to the remaining target types. It overlaps the open pull request **"Bugfix for 'No Target Identified'"**, which applies the same idea to `/cw/{vanity}` pages only — happy to close this one if you prefer that.
